### PR TITLE
docs: add design plans for different pages

### DIFF
--- a/assets/doc/login-page-plan.md
+++ b/assets/doc/login-page-plan.md
@@ -1,0 +1,29 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner with icon and brand name.
+    Navigation Menu:
+        Home: Clickable text leading to the homepage.
+        Languages: Clickable text leading to the languages section.
+        About Us: Clickable text leading to the about page.
+    Start Learning Button: Top-right, with border and hover highlight.
+
+Main Content Section
+
+    Heading:
+        "Log in and start learning": Bold, large font, centered.
+    Login Form:
+        Email Field: Rectangular input box.
+        Password Field: Rectangular input box.
+            Show Password Checkbox: Toggles password visibility.
+        Login Button: Rounded rectangular, blue, changes color on hover.
+        Forgot Email & Forgot Password Links: Clickable text links.
+    Sign-Up Section:
+        Sign-Up Button: Rounded rectangular, dark blue, changes color on hover.
+
+Footer Section
+
+    Social Media Icons: Facebook, Instagram, Email.
+    Legal and Policy Links: Privacy Policy, Terms & Conditions.
+    Learning Resources: Languages Offered, Community Forum, Mobile App.
+    Support Links: Help Center, Refund Policy, FAQs.
+    Copyright Notice: "© 2025 Langora. All rights reserved.", bottom-left corner.

--- a/assets/doc/platform-management-page-admin.md
+++ b/assets/doc/platform-management-page-admin.md
@@ -1,0 +1,37 @@
+Header Section
+    Logo (Langora): Positioned at the top-left corner.
+
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Validate: A clickable text linking to the validation section.
+        Friends: A clickable text linking to the friends section.
+
+    Page Title:
+        "Platform Management": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+
+    Sidebar Menu Options:
+        User List (Profile icon)
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)
+
+Main Content Section
+    Add Platform Button:
+        A rounded rectangular button labeled "Add Platform," positioned at the top-right.
+        Styled with a blue border and background highlight on hover.
+
+    Platform Management Table:
+        Columns:
+            ID: Unique identifier for each platform.
+            Name: Platform name.
+            Website: URL of the platform.
+            Languages Offered: List of languages provided by the platform.
+            Actions: Section for managing the platform (e.g., edit, delete buttons).
+        Styled with a blue header background and dark blue text.
+        Borders and layout ensure clarity and organization.

--- a/assets/doc/platform-ranking-and-sorting-admin-plan.md
+++ b/assets/doc/platform-ranking-and-sorting-admin-plan.md
@@ -1,0 +1,30 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner.
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Validate: A clickable text linking to the validation section.
+        Friends: A clickable text linking to the friends section.
+    Page Title:
+        "Platform Ranking & Sorting": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+    Sidebar Menu Options:
+        User List (Profile icon)
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)
+
+Main Content Section
+
+    Sorting Controls:
+        Sort by Rating: A dropdown menu for selecting sorting criteria.
+        Sort: A rounded rectangular button to apply the sorting.
+    Data Table:
+        Columns: ID, Name, Average Rating, Popularity (Reviews), Description.
+        Currently empty, indicating no data loaded.

--- a/assets/doc/platform-submission-plan.md
+++ b/assets/doc/platform-submission-plan.md
@@ -1,0 +1,33 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner.
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Practice: A clickable text linking to practice exercises.
+        Friends: A clickable text linking to the friends section.
+    Page Title:
+        "PLATFORM SUBMISSION": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+    Sidebar Menu Options:
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)
+
+Main Content Section
+
+    Form Title:
+        "SUBMIT A NEW PLATFORM": Standard text.
+    Form Fields:
+        Platform: Input field for platform name.
+        Website: Input field for platform website.
+        Languages Offered: Input field for languages offered.
+        Description: Input field for platform description.
+    Form Buttons:
+        Cancel: A button labeled "Cancel."
+        Add Platform: A button labeled "Add Platform."

--- a/assets/doc/reviews-and-ratings-admin-plan.md
+++ b/assets/doc/reviews-and-ratings-admin-plan.md
@@ -1,0 +1,29 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner.
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Validate: A clickable text linking to the validation section.
+        Friends: A clickable text linking to the friends section.
+    Page Title:
+        "Reviews & Ratings": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+    Sidebar Menu Options:
+        User List (Profile icon)
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)t
+
+Main Content Section
+
+    Add Review Button:
+        A rounded rectangular button labeled "Add Review."
+    Data Table:
+        Columns: Review ID, Platform ID, User ID, Rating, Comment, Actions.
+        Currently empty, indicating no data loaded.

--- a/assets/doc/reviews-user-plan.md
+++ b/assets/doc/reviews-user-plan.md
@@ -1,0 +1,31 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner.
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Practice: A clickable text linking to practice exercises.
+        Friends: A clickable text linking to the friends section.
+    Page Title:
+        "FEEDBACK & REVIEWS": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+    Sidebar Menu Options:
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)
+
+Main Content Section
+
+    Form Title:
+        "ADD REVIEW": Standard text.
+    Form Fields:
+        Platform: Dropdown menu labeled "Select Platform."
+        Your Review: Large input field for review text.
+        Rating: Star rating input (5 stars).
+    Form Button:
+        Add Review: A button labeled "Add Review."

--- a/assets/doc/settings-page-plan.md
+++ b/assets/doc/settings-page-plan.md
@@ -1,0 +1,41 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner.
+
+    Navigation Menu:
+        Learn: A clickable text linking to the learning section.
+        Practice: A clickable text linking to practice exercises.
+        Friends: A clickable text linking to the friends section.
+
+    Page Title:
+        "SETTINGS": Displayed in bold, uppercase, orange text.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user streak or points.
+        A country flag icon (French), representing the selected language.
+
+    Sidebar Menu Options:
+        User List (Profile icon)
+        Platforms (Document icon)
+        Review/Rating (Trophy icon)
+        Sorting (Sorting icon)
+        Settings (Gear icon)
+
+Main Content Section
+
+    Account Settings:
+        Preferences: A rounded rectangular button.
+        Notifications: A rounded rectangular button.
+        Courses: A rounded rectangular button.
+        Subscription: A rounded rectangular button.
+        Privacy Settings: A rounded rectangular button.
+
+    Support Settings:
+        Preferences: A rounded rectangular button.
+        Notifications: A rounded rectangular button.
+
+    Sign Out Button:
+        A large, rounded rectangular button with a blue background.
+        Changes color on hover.

--- a/assets/doc/user-management-admin-plan.md
+++ b/assets/doc/user-management-admin-plan.md
@@ -1,0 +1,38 @@
+Header Section
+
+    Logo (Langora): Positioned at the top-left corner with an icon.
+    Navigation Menu:
+        Learn: A clickable text linking to learning features.
+        Validate: A clickable text linking to the validation section.
+        Friends: A clickable text linking to the friends section.
+
+Sidebar Navigation
+
+    User Progress:
+        A flame icon with the number "7," indicating user activity or engagement.
+        A French flag icon, for language selection.
+    Sidebar Menu Options:
+        User List (Icon present)
+        Platforms (Icon present)
+        Review/Rating (Icon present)
+        Sorting (Icon present)
+        Settings (Icon present)
+
+Main Content Section
+
+    Page Title:
+        "User Management": Displayed in bold, orange text.
+    Search Bar:
+        "Search by Email...": A small input field for filtering users.
+    Add User Button:
+        A rounded button labeled "Add User" (blue).
+    Data Table:
+        Columns: ID, Email, Name, Actions.
+        Currently empty, indicating no data loaded.
+
+Functionalities & Interactions
+
+    Search Feature: Allows searching users by email.
+    Add User Button: Opens a modal or new page for adding users.
+    Sidebar Navigation: Clicking menu items redirects to corresponding sections.
+    Language Selector: Changes the interface language.


### PR DESCRIPTION
Markdown files were added outlining the design plans for various pages in the docs directory. These files will serve as references for the website's structure and layout.